### PR TITLE
fix antenna house path bug on windows

### DIFF
--- a/com.oxygenxml.pdf.css/build.xml
+++ b/com.oxygenxml.pdf.css/build.xml
@@ -186,16 +186,18 @@ with those set forth herein.
   	<property name="main.css.path" value="${dita.temp.dir.fullpath}/main.css"/>
   	<script language="javascript">
   	 <![CDATA[
-		var tmp = "";
-  	    var arr = project.getProperty('dita.css.list').split(';'); 
-  	    for (i = 0; i < arr.length; i++) {
-			if (arr[i].length() > 0) {
-		  		  tmp = tmp.concat("@import '");
-	  			  tmp = tmp.concat(arr[i]);
-	  	    	  tmp = tmp.concat("';\n");  
-  		   	}
-  	    }
-  		project.setProperty('main.css.content', tmp);
+	 var tmp = "";
+	 var path = project.getProperty('dita.css.list');
+	 pathFixed = path.replace(/\\/g, "/");
+	 var arr = pathFixed.split(';'); 
+         for (i = 0; i < arr.length; i++) {
+  	   if (arr[i].length() > 0) {
+ 	  	  tmp = tmp.concat("@import 'file:///");
+	 	  tmp = tmp.concat(arr[i]);
+	  	  tmp = tmp.concat("';\n");  
+	   }
+  	 }
+  	 project.setProperty('main.css.content', tmp);
   	 ]]>
   	 </script>
   	<echo file="${main.css.path}">${main.css.content}</echo>


### PR DESCRIPTION
Antenna House v6.2 64-bit could not find style-basic.css on my Windows 7 pc, and therefore no styling of the PDF was done. This was because of 2 problems with the path to style-basic.css in the generated main.css file:
1. It needed `file:///` prepended to the URL.
2. It needed backslashes changed to forward slashes.

So my changes turned this:

```
@import 'C:\Program Files (x86)\Oxygen XML Editor 17\frameworks\dita\css/edit/style-basic.css';
```

into this:

```
@import 'file:///C:/Program Files (x86)/Oxygen XML Editor 17/frameworks/dita/css/edit/style-basic.css';
```

These changes fixed it for me, and that's what this PR contains. I guess AH needs these things. I only tested this on 64-bit Win7 Pro with the 64-bit version of AH (evaluation copy).
